### PR TITLE
Allow sslmode to be specified in REDSHIFT_URL

### DIFF
--- a/lib/redshift/client/configuration.rb
+++ b/lib/redshift/client/configuration.rb
@@ -7,7 +7,7 @@ module Redshift
     class Configuration
       attr_reader :host, :port, :user, :password, :dbname
 
-      DEFAULT_SSL_MODE = 'require'.freeze
+      DEFAULT_SSL_MODE = 'allow'.freeze
 
       class << self
         def resolve(config = {})

--- a/lib/redshift/client/configuration.rb
+++ b/lib/redshift/client/configuration.rb
@@ -1,10 +1,13 @@
 require 'uri'
+require 'cgi'
 require 'active_support/core_ext/hash/reverse_merge'
 
 module Redshift
   module Client
     class Configuration
       attr_reader :host, :port, :user, :password, :dbname
+
+      DEFAULT_SSL_MODE = 'require'.freeze
 
       class << self
         def resolve(config = {})
@@ -15,31 +18,42 @@ module Redshift
             config[:port],
             config[:user],
             config[:password],
-            config[:dbname]
+            config[:dbname],
+            config[:sslmode]
           )
         end
 
         private
+
         def parse_redshift_url
-          uri = URI.parse(ENV["REDSHIFT_URL"])
+          uri = URI.parse(ENV['REDSHIFT_URL'])
           {
             host: uri.host,
             port: uri.port,
             user: uri.user,
             password: uri.password,
-            dbname: uri.path[1..-1]
+            dbname: uri.path[1..-1],
+            sslmode: sslmode(uri)
           }
         rescue
           {}
         end
+
+        def sslmode(uri)
+          if uri.query
+            param = CGI.parse(uri.query)['sslmode']
+            param && param[0]
+          end
+        end
       end
 
-      def initialize(host, port, user, password, dbname)
+      def initialize(host, port, user, password, dbname, sslmode)
         @host = host
         @port = port || 5439
         @user = user
         @password = password
         @dbname = dbname
+        @sslmode = sslmode || DEFAULT_SSL_MODE
       end
 
       def params
@@ -48,7 +62,8 @@ module Redshift
           port: @port,
           user: @user,
           password: @password,
-          dbname: @dbname
+          dbname: @dbname,
+          sslmode: @sslmode
         }
       end
     end

--- a/lib/redshift/client/connection_handling.rb
+++ b/lib/redshift/client/connection_handling.rb
@@ -4,7 +4,7 @@ require 'active_support/lazy_load_hooks'
 module Redshift
   module Client
     module ConnectionHandling
-      def establish_connection(config= {})
+      def establish_connection(config = {})
         clear_connection!
         clear_thread!
 

--- a/spec/redshift/client/configuration_spec.rb
+++ b/spec/redshift/client/configuration_spec.rb
@@ -13,7 +13,8 @@ describe Redshift::Client::Configuration do
         port: 5439,
         user: "root",
         password: "password",
-        dbname: "dev"
+        dbname: "dev",
+        sslmode: "require"
       }
     end
 


### PR DESCRIPTION
We needed the ability to specify an ssl mode to connect to our cluster, which wasn't previously available.

Defaults to `require` if it's not supplied.