### PR TITLE
Feature/cast timezones properly

### DIFF
--- a/lib/redshift/client/configuration.rb
+++ b/lib/redshift/client/configuration.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'cgi'
-require 'active_support/core_ext/hash/reverse_merge'
 
 module Redshift
   module Client
@@ -11,7 +10,7 @@ module Redshift
 
       class << self
         def resolve(config = {})
-          config.reverse_merge!(parse_redshift_url)
+          config = parse_redshift_url.merge!(config)
 
           Configuration.new(
             config[:host],

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -18,7 +18,8 @@ module Redshift
         :escape,
         :escape_string,
         :escape_literal,
-        :close
+        :close,
+        :transaction
     end
   end
 end

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -19,7 +19,8 @@ module Redshift
         :escape_string,
         :escape_literal,
         :close,
-        :transaction
+        :transaction,
+        :quote_ident
     end
   end
 end

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -11,16 +11,17 @@ module Redshift
         @original = PG.connect(configuration.params)
       end
 
-      def_delegators \
-        :@original,
-        :exec,
-        :exec_params,
-        :escape,
-        :escape_string,
-        :escape_literal,
-        :close,
-        :transaction,
-        :quote_ident
+      def method_missing(method_name, *args, &block)
+        if @original.respond_to?(method_name)
+          @original.send(method_name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        @original.respond_to?(method_name, include_private) || super
+      end
     end
   end
 end

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -1,23 +1,24 @@
 require 'pg'
-require 'active_support/core_ext/module'
+require 'forwardable'
 
 module Redshift
   module Client
     class Connection
+      extend Forwardable
       attr_reader :original
 
       def initialize(configuration)
         @original = PG.connect(configuration.params)
       end
 
-      delegate \
+      def_delegators \
+        :@original,
         :exec,
         :exec_params,
         :escape,
         :escape_string,
         :escape_literal,
-        :close,
-        to: :original
+        :close
     end
   end
 end

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -7,7 +7,7 @@ module Redshift
 
       def initialize(configuration)
         @original = PG.connect(configuration.params)
-        @original.type_map_for_results = PG::BasicTypeMapForResults.new(@original)
+        @original.type_map_for_results = extended_type_map_for(@original)
       end
 
       def method_missing(method_name, *args, &block)
@@ -20,6 +20,22 @@ module Redshift
 
       def respond_to_missing?(method_name, include_private = false)
         @original.respond_to?(method_name, include_private) || super
+      end
+
+      private
+
+      def extended_type_map_for(connection)
+        PG::BasicTypeMapForResults.new(connection, registry: registry)
+      end
+
+      def registry
+        # PG::BasicTypeMap assumes DB is in the same tz as application
+        # This extension supports Database which stores data in UTC if the column type is timezone(without zone)
+        timestamp_tz_parser_klass = PG::TextDecoder::TimestampUtcToLocal
+        registry = PG::BasicTypeRegistry.new
+        registry.register_default_types
+        registry.register_type(0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, timestamp_tz_parser_klass)
+        registry
       end
 
     end

--- a/lib/redshift/client/connection.rb
+++ b/lib/redshift/client/connection.rb
@@ -9,6 +9,7 @@ module Redshift
 
       def initialize(configuration)
         @original = PG.connect(configuration.params)
+        @original.type_map_for_results = PG::BasicTypeMapForResults.new(@original)
       end
 
       def_delegators \
@@ -19,8 +20,7 @@ module Redshift
         :escape_string,
         :escape_literal,
         :close,
-        :transaction,
-        :quote_ident
+        :transaction
     end
   end
 end

--- a/lib/redshift/client/connection_handling.rb
+++ b/lib/redshift/client/connection_handling.rb
@@ -1,5 +1,4 @@
 require 'thread'
-require 'active_support/lazy_load_hooks'
 
 module Redshift
   module Client
@@ -13,8 +12,6 @@ module Redshift
 
       def connection
         return current[:connection] if connected?
-
-        ActiveSupport.run_load_hooks :redshift_client_connection
 
         check_established!
         current[:connection] = Connection.new(current[:configuration])

--- a/lib/redshift/client/loggable.rb
+++ b/lib/redshift/client/loggable.rb
@@ -1,5 +1,3 @@
-require 'active_support'
-require 'active_support/core_ext/class/attribute_accessors'
 require 'logger'
 
 module Redshift

--- a/redshift-client.gemspec
+++ b/redshift-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pg"
   spec.add_runtime_dependency "activesupport", ">= 4"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/redshift-client.gemspec
+++ b/redshift-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", ">= 4"
 
   spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/redshift-client.gemspec
+++ b/redshift-client.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "pg"
-  spec.add_runtime_dependency "activesupport", ">= 4"
 
   spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "dotenv"

--- a/spec/redshift/client/configuration_spec.rb
+++ b/spec/redshift/client/configuration_spec.rb
@@ -4,6 +4,14 @@ describe Redshift::Client::Configuration do
   describe "#resolve" do
     subject { Redshift::Client::Configuration.resolve({host: "localhost"}) }
     it { is_expected.to be_a Redshift::Client::Configuration }
+
+    context "when host param differs from redshift URL" do
+      subject { Redshift::Client::Configuration.resolve({host: "my.redshift.com"}) }
+
+      it "should NOT override params with the resolved redshift url" do
+        expect(subject.host).to eq('my.redshift.com')
+      end
+    end
   end
 
   describe "#params" do

--- a/spec/redshift/client/connection_spec.rb
+++ b/spec/redshift/client/connection_spec.rb
@@ -3,10 +3,19 @@ require 'spec_helper'
 describe Redshift::Client::Connection do
   let(:configuration) { Redshift::Client::Configuration.resolve }
   let(:connection) { double('connection', 'type_map_for_results=' => nil, 'exec' => nil) }
+  let(:registry) { double('registry') }
 
   describe "#initialize" do
     before do
       allow(PG).to receive(:connect)
+      allow(PG::BasicTypeRegistry).to receive(:new).and_return(registry)
+      allow(registry)
+        .to receive(:register_default_types)
+      allow(registry)
+        .to receive(:coders_for)
+      allow(registry)
+        .to receive(:register_type)
+        .with(0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, PG::TextDecoder::TimestampUtcToLocal)
     end
 
     it "calls PG#connect" do
@@ -26,7 +35,7 @@ describe Redshift::Client::Connection do
         .and_return(connection)
       expect(PG::BasicTypeMapForResults)
         .to receive(:new)
-        .with(connection)
+        .with(connection, registry: registry)
         .once
       Redshift::Client::Connection.new(configuration)
     end

--- a/spec/redshift/client/connection_spec.rb
+++ b/spec/redshift/client/connection_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Redshift::Client::Connection do
   let(:configuration) { Redshift::Client::Configuration.resolve }
+  let(:connection) { double('connection', 'type_map_for_results=' => nil, 'exec' => nil) }
 
   describe "#initialize" do
     before do
@@ -9,8 +10,25 @@ describe Redshift::Client::Connection do
     end
 
     it "calls PG#connect" do
+      expect(PG)
+        .to receive(:connect)
+        .with(configuration.params)
+        .once
+        .and_call_original
       Redshift::Client::Connection.new(configuration)
-      expect(PG).to have_received(:connect).with(configuration.params).once
+    end
+
+    it "registers basic type maps for JSON parsing" do
+      expect(PG)
+        .to receive(:connect)
+        .with(configuration.params)
+        .once
+        .and_return(connection)
+      expect(PG::BasicTypeMapForResults)
+        .to receive(:new)
+        .with(connection)
+        .once
+      Redshift::Client::Connection.new(configuration)
     end
   end
 end

--- a/spec/redshift/client_spec.rb
+++ b/spec/redshift/client_spec.rb
@@ -63,19 +63,6 @@ describe Redshift::Client do
         expect(Redshift::Client.connection).to be_instance_of Redshift::Client::Connection
       end
     end
-
-    context "when not yet established" do
-      before do
-        allow(ActiveSupport).to receive :run_load_hooks
-      end
-
-      it "calls ActiveSupport#run_load_hooks and raise error" do
-        Thread.new {
-          expect { Redshift::Client.connection }.to raise_error(Redshift::Client::ConnectionNotEstablished)
-          expect(ActiveSupport).to have_received(:run_load_hooks).with(:redshift_client_connection).once
-        }.join
-      end
-    end
   end
 
   describe "#established?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+require 'dotenv'
+Dotenv.load
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'redshift/client'


### PR DESCRIPTION
PG connection originally suppose the DB timezone is in the same as application timezone if you use basic type map provided by the gem.

When pg decodes the result it is using the client timezone but not adding the offset for the UTC value
eg: updated_at in column: '2023-06-16 12:33:11' is parsed as '2023-06-16 12:33:11 +1000' if you application timezone is in +10. 

PG supported coders: https://deveiate.org/code/pg/README_md.html#label-Type+Casts

Basic type map using [TimestampLocal](https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/lib/pg/text_decoder/timestamp.rb#L19) which causes the bug in our case since the DB is in UTC.

For the fix we needed to register [TimestampUtcToLocal](https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/lib/pg/text_decoder/timestamp.rb#L13) to decode properly timestamps
